### PR TITLE
Fix BaseEvent inheritance

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -920,7 +920,7 @@ declare module d3 {
     export function flush(): void;
   }
 
-   interface BaseEvent {
+   interface BaseEvent extends Event {
      type: string;
      sourceEvent?: Event;
    }


### PR DESCRIPTION
This PR fixes the following errors:

```
(237,36): error TS2339: Property 'layerX' does not exist on type 'Event | BaseEvent'.
(236,56): error TS2339: Property 'layerY' does not exist on type 'Event | BaseEvent'.
(8,14): error TS2339: Property 'stopPropagation' does not exist on type 'Event | BaseEvent'.
```
